### PR TITLE
Edgeguard shifty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ tcppush: tcppush.o copyfd.o miscutils.o netutils.o
 tcpcat: tcpcat.o copyfd.o miscutils.o netutils.o
 tcprelay: tcprelay.o copyfd.o miscutils.o netutils.o
 
-copyfd.o: ringbufr.h
+copyfd.o: ringbufr.h ringbufr.tcc
 ringcat.o: copyfd.h
 testring.o: posix_ringbufr.h ringbufr.h ringbufr.tcc
 tcpget.o: copyfd.h miscutils.h netutils.h
@@ -28,5 +28,5 @@ tcppull.o: copyfd.h miscutils.h netutils.h
 tcppush.o: copyfd.h miscutils.h netutils.h
 tcpcat.o: copyfd.h miscutils.h netutils.h
 tcprelay.o: copyfd.h miscutils.h netutils.h
-netutils.o: netutils.h miscutils.h
+netutils.o: netutils.h miscutils.h ringbufr.h
 miscutils.o: miscutils.h

--- a/copyfd.cc
+++ b/copyfd.cc
@@ -19,13 +19,13 @@ using namespace std::chrono;
         /* std::cerr << "checkpoint " << __LINE__ << std::endl; */ \
     } while (false)
 
-size_t copyfd(int readfd, int writefd, size_t chunk_size)
+size_t copyfd(int readfd, int writefd, size_t chunk_size, size_t pad)
 {
     int maxfd = std::max(readfd, writefd) + 1;
     fd_set read_set;
     fd_set write_set;
 
-    RingbufR<unsigned char> bufr(3 * chunk_size);
+    RingbufR<unsigned char> bufr(3 * chunk_size, pad);
 
     ssize_t bytes_read = 0;
     ssize_t bytes_write = 0;

--- a/copyfd.h
+++ b/copyfd.h
@@ -2,6 +2,6 @@
 #define __FD_COPY_H_
 #include <unistd.h>
 
-size_t copyfd(int readfd, int writefd, size_t chunk_size);
+size_t copyfd(int readfd, int writefd, size_t chunk_size, size_t pad=0);
 
 #endif // __FD_COPY_H_

--- a/posix_ringbufr.h
+++ b/posix_ringbufr.h
@@ -14,8 +14,8 @@ class Posix_RingbufR : public RingbufR<_T>
 {
 public:
 
-    Posix_RingbufR (size_t capacity, int verbose)
-        : RingbufR<_T> (capacity), _verbose(verbose)
+    Posix_RingbufR (size_t capacity, int verbose, ssize_t edge_guard = 0)
+        : RingbufR<_T> (capacity, edge_guard), _verbose(verbose)
     {
     }
 

--- a/ringbufr.h
+++ b/ringbufr.h
@@ -53,7 +53,7 @@ protected:
 
 private:
 
-    size_t compute_move(size_t& guard_available) const;
+    size_t compute_right() const;
 };
 
 // Implementation

--- a/ringbufr.h
+++ b/ringbufr.h
@@ -35,6 +35,7 @@ public:
     void push(size_t newContent);
     void popInquire(size_t& available, _T*& start) const;
     void pop(size_t oldContent);
+    size_t size() const;
 
 protected:
 

--- a/ringbufr.h
+++ b/ringbufr.h
@@ -37,6 +37,9 @@ public:
     void pop(size_t oldContent);
     size_t size() const;
 
+    // For debugging
+    const _T* ring_start() const;
+
 protected:
 
     virtual void updateStart(size_t increment);

--- a/ringbufr.h
+++ b/ringbufr.h
@@ -26,7 +26,7 @@ class RingbufR
 {
 public:
 
-    RingbufR (size_t capacity);
+    RingbufR (size_t capacity, size_t edge_guard = 0);
     virtual ~RingbufR ();
     RingbufR() = delete; // No default constructor
     RingbufR(const RingbufR<_T>&) = delete; // No copy constructor
@@ -42,11 +42,18 @@ protected:
     virtual void updateEnd(size_t increment);
 
     const size_t _capacity;
+    const size_t _edge_guard;
+    _T* const _edge_start;
     _T* const _ring_start;
     _T* const _ring_end;
+    _T* const _edge_end;
     bool _empty;
     _T* _push_next;
     _T* _pop_next;
+
+private:
+
+    size_t compute_move(size_t& guard_available) const;
 };
 
 // Implementation

--- a/ringbufr.h
+++ b/ringbufr.h
@@ -44,16 +44,12 @@ protected:
     const size_t _capacity;
     const size_t _edge_guard;
     _T* const _edge_start;
-    _T* const _ring_start;
-    _T* const _ring_end;
     _T* const _edge_end;
     bool _empty;
     _T* _push_next;
     _T* _pop_next;
-
-private:
-
-    size_t compute_right() const;
+    _T* _ring_start;
+    _T* _ring_end;
 };
 
 // Implementation

--- a/ringbufr.tcc
+++ b/ringbufr.tcc
@@ -167,7 +167,7 @@ void RingbufR<_T>::updateStart(size_t increment)
     // Update complete.
     _pop_next = new_next;
 
-    // Shift buffer to right if appropriate.
+    // Shift buffer to minimize edge effects. Two cases to consider.
     if (_push_next <= _pop_next)
     {
         // Wrap-around is in effect. Maybe eliminate it.

--- a/ringbufr.tcc
+++ b/ringbufr.tcc
@@ -193,17 +193,8 @@ void RingbufR<_T>::updateStart(size_t increment)
         size_t unused_ring = _pop_next - _ring_start;
         size_t unused_buffer = _edge_end - _ring_end;
         size_t right_shift = std::min(unused_ring, unused_buffer);
-        // Stop at _edge_guard (centered)
-        if ((_ring_start + right_shift) > (_edge_start + _edge_guard))
-        {
-            _ring_start = _edge_start + _edge_guard;
-            _ring_end   = _ring_start + _capacity;
-        }
-        else
-        {
-            _ring_start += right_shift;
-            _ring_end   += right_shift;
-        }
+        _ring_start += right_shift;
+        _ring_end   += right_shift;
     }
 
     if (_pop_next == _ring_end) _pop_next = _ring_start;

--- a/ringbufr.tcc
+++ b/ringbufr.tcc
@@ -12,7 +12,7 @@ RingbufR<_T>::RingbufR (size_t capacity, size_t edge_guard)
       _edge_start(new _T[capacity + 2*edge_guard]),
       _edge_end(_edge_start + capacity + 2*edge_guard)
 {
-    _ring_start = _edge_start + edge_guard;
+    _ring_start = _edge_start + 2*edge_guard;
     _ring_end   = _ring_start + capacity;
     _push_next  = _ring_start;
     _pop_next   = _ring_start;

--- a/ringbufr.tcc
+++ b/ringbufr.tcc
@@ -1,12 +1,16 @@
 // Implementation of RingbufR
 
 #include <cassert>
+#include <algorithm>
 
 template<typename _T>
-RingbufR<_T>::RingbufR (size_t capacity)
+RingbufR<_T>::RingbufR (size_t capacity, size_t edge_guard)
     : _capacity(capacity),
-      _ring_start(new _T[capacity]),
-      _ring_end(_ring_start + capacity)
+      _edge_guard(edge_guard),
+      _edge_start(new _T[capacity + 2*edge_guard]),
+      _ring_start(_edge_start + edge_guard),
+      _ring_end(_ring_start + capacity),
+      _edge_end(_ring_end + edge_guard)
 {
     _empty = true;
     _push_next = _ring_start;
@@ -16,65 +20,95 @@ RingbufR<_T>::RingbufR (size_t capacity)
 template<typename _T>
 RingbufR<_T>::~RingbufR()
 {
-    delete[] _ring_start;
+    delete[] _edge_start;
+}
+
+template<typename _T>
+size_t RingbufR<_T>::compute_move(size_t& guard_available) const
+{
+    guard_available = 0;
+    size_t available = _ring_end - _push_next;
+    if (available < _edge_guard)
+    {
+        if (_pop_next > _ring_start)
+        {
+            guard_available = _pop_next - _ring_start;
+            std::size_t excess = _edge_guard - available;
+            guard_available = std::min(guard_available, excess);
+            available += guard_available;
+        }
+    }
+    return available;
 }
 
 template<typename _T>
 void RingbufR<_T>::pushInquire(size_t& available, _T*& start) const
 {
-    if (_empty)
+    // Take care of a special case
+    if (!_empty && (_push_next == _pop_next))
     {
-        assert(_push_next == _pop_next);
-        available = _ring_end - _push_next;
+        // Buffer is full
+        available = 0;
+        start = nullptr;
+        return;
+    }
+
+    if (_push_next < _pop_next)
+    {
+        // Wrap-around is in effect
+        available = _pop_next - _push_next;
     }
     else
     {
-        if (_push_next <= _pop_next)
-        {
-            // Deal with wrap-around
-            available = _pop_next - _push_next;
-        }
-        else
-        {
-            available = _ring_end - _push_next;
-        }
+        size_t guard_available;
+        available = compute_move(guard_available);
     }
     start = _push_next;
 }
 
+// push
 template<typename _T>
 void RingbufR<_T>::updateEnd(size_t increment)
 {
+    // Take care of special cases
     if (increment == 0) return;
-
-    auto new_next = _push_next + increment;
-    _T* limit;
-    if (_empty)
+    if (!_empty && (_push_next == _pop_next))
     {
-        assert(_push_next == _pop_next);
-        limit = _ring_end;
-        _empty = false;
+        // Buffer is full, so corruption has already occurred.
+        throw RingbufRFullException();
+    }
+    _empty = false;
+
+    _T* limit;
+    size_t guard_available = 0;
+    if (_push_next < _pop_next)
+    {
+        // Wrap-around is in effect
+        limit = _pop_next;
     }
     else
     {
-        if (_push_next <= _pop_next)
-        {
-            // Deal with wrap-around
-            limit = _pop_next;
-        }
-        else
-        {
-            limit = _ring_end;
-        }
+        size_t available = compute_move(guard_available);
+        limit = _push_next + available;
     }
-
-    if (new_next > limit)
+    _push_next += increment;
+    if (_push_next > limit)
     {
         // Corruption has already occurred.
         throw RingbufRFullException();
     }
-    if (new_next == _ring_end) new_next = _ring_start;
-    _push_next = new_next;
+
+    // Wrap-around could begin here
+    if (guard_available > 0)
+    {
+        // Move excess data to start
+        _push_next = _ring_start + guard_available;
+        _T* source = _ring_end;
+        _T* dest   = _ring_start;
+        while (guard_available--)
+            *dest++ = *source++;
+    }
+    if (_push_next == _ring_end) _push_next = _ring_start;
 }
 
 template<typename _T>
@@ -86,55 +120,70 @@ void RingbufR<_T>::push(size_t newContent)
 template<typename _T>
 void RingbufR<_T>::popInquire(size_t& available, _T*& start) const
 {
+    // Take care of special case
     if (_empty)
     {
         assert(_push_next == _pop_next);
         available = 0;
+        start = nullptr;
+        return;
+    }
+
+    if (_push_next <= _pop_next)
+    {
+        // Wrap-around is in effect
+        available = _ring_end - _pop_next;
     }
     else
     {
-        if (_push_next <= _pop_next)
-        {
-            // Deal with wrap-around
-            available = _ring_end - _pop_next;
-        }
-        else
-        {
-            available = _push_next - _pop_next;
-        }
+        available = _push_next - _pop_next;
     }
     start = _pop_next;
 }
 
+// pop
 template<typename _T>
 void RingbufR<_T>::updateStart(size_t increment)
 {
+    // Take care of special cases
     if (increment == 0) return;
+    if (_empty) throw RingbufREmptyException();
 
-    auto new_next = _pop_next + increment;
     _T* limit;
-    if (_empty)
+    _T* new_next = _pop_next + increment;
+#ifdef LATER
+    size_t stub_data = 0;
+#endif
+    if (_push_next <= _pop_next)
     {
-        assert(_push_next == _pop_next);
+        // Wrap around is in effect
         limit = _ring_end;
+#ifdef LATER
+        stub_data = _ring_end - new_next;
+#endif
     }
     else
     {
-        if (_push_next <= _pop_next)
-        {
-            // Deal with wrap-around
-            limit = _ring_end;
-        }
-        else
-        {
-            limit = _push_next;
-        }
+        limit = _push_next;
     }
     if (new_next > limit)
     {
         // Invalid data has already been copied out
         throw RingbufREmptyException();
     }
+
+#ifdef LATER
+    // Edge guard: move data from end of buffer.
+    if (stub_data < _edge_guard)
+    {
+        _T* source = new_next;
+        new_next = _ring_start - stub_data;
+        _T* dest = new_next;
+        while (stub_data-- > 0)
+            *dest++ = *source++;
+    }
+#endif
+
     if (new_next == _ring_end) new_next = _ring_start;
     _pop_next = new_next;
     _empty = (_pop_next == _push_next);

--- a/tcpcat.cc
+++ b/tcpcat.cc
@@ -92,10 +92,10 @@ int main (int argc, char* argv[])
 #ifdef VERBOSE
     std::cerr << "starting copy, socket " << input_socket <<
         " to socket " << output_socket << std::endl;
-    auto bytes_processed = copyfd(input_socket, output_socket, 131072);
+    auto bytes_processed = copyfd(input_socket, output_socket, 126*1024, 2*1024);
     std::cerr << bytes_processed << " copied" << std::endl;
 #else
-    copyfd(input_socket, output_socket, 131072);
+    copyfd(input_socket, output_socket, 126*1024, 2*1024);
 #endif
 
     close(output_socket);

--- a/testring.cc
+++ b/testring.cc
@@ -69,7 +69,7 @@ int main (int argc, char* argv[])
     // Cheat
     size_t available;
     rbuf.pushInquire(available, buffer);
-    buffer -= guard_size;
+    buffer -= 2*guard_size;
 
     std::thread hReader (Reader);
     std::thread hWriter (Writer);

--- a/testring.cc
+++ b/testring.cc
@@ -137,14 +137,13 @@ static void Reader ()
         rbuf.popInquire(available, start);
         if (available)
         {
-            ssize_t count = 1;
+            size_t count = 1;
             if (available > 1)
                 count = (rand() % (available-1)) + 1;
             if (verbose >= 1)
                 std::cout << "(will pop " << count <<
                 " starting at " << start - buffer << ")" << std::endl;
-            ssize_t i = count;
-            while (i-- > 0)
+            for (size_t i = 0 ; i < count ; ++i)
             {
                 ++serial;
                 auto observed = start->serialNumber;

--- a/testring.cc
+++ b/testring.cc
@@ -12,9 +12,9 @@
 // Tuning
 static const int read_usleep_range  = 1000000;
 static const int write_usleep_range = 1000000;
-static const int buffer_size = 37;
-static const int guard_size = 7;
-static const int verbose = 1;
+static const size_t buffer_size = 37;
+static const size_t guard_size = 7;
+static const size_t verbose = 1;
 // #define USE_POSIX
 #define DEFAULT_RUN_SECONDS 300
 
@@ -70,11 +70,11 @@ int main (int argc, char* argv[])
     // Cheat
     size_t available;
     rbuf.pushInquire(available, buffer);
-    
+
     std::thread hReader (Reader);
     std::thread hWriter (Writer);
     sleep (run_seconds);
-    
+
     running = false;
     hWriter.join();
     hReader.join();
@@ -97,9 +97,12 @@ static void Writer ()
             size_t count = 1;
             if (available > 1)
                 count = (rand() % (available-1)) + 1;
+            // Temporary, test of edge guard
+            if (available >= guard_size)
+                count = std::max(count, guard_size);
             if (verbose >= 1)
             {
-                std::cout << "(pushing " << count <<
+                std::cout << "(will push " << count <<
                     " at " << start - buffer <<
                     " starting with value " << serial + 1 << ")" << std::endl;
             }
@@ -118,6 +121,7 @@ static void Writer ()
                 std::cout << "Write failure" << std::endl;
                 exit(1);
             }
+            std::cout << "size is now " << rbuf.size() << std::endl;
         }
     }
 }
@@ -140,6 +144,9 @@ static void Reader ()
             size_t count = 1;
             if (available > 1)
                 count = (rand() % (available-1)) + 1;
+            // Temporary, test of edge guard
+            if (available >= guard_size)
+                count = std::max(count, guard_size);
             if (verbose >= 1)
                 std::cout << "(will pop " << count <<
                 " starting at " << start - buffer << ")" << std::endl;
@@ -165,6 +172,7 @@ static void Reader ()
                 std::cout << "Read failure " << std::endl;
                 exit(1);
             }
+            std::cout << "size is now " << rbuf.size() << std::endl;
         }
         else if (!running)
         {

--- a/testring.cc
+++ b/testring.cc
@@ -70,6 +70,7 @@ int main (int argc, char* argv[])
     // Cheat
     size_t available;
     rbuf.pushInquire(available, buffer);
+    buffer -= guard_size;
 
     std::thread hReader (Reader);
     std::thread hWriter (Writer);
@@ -121,7 +122,8 @@ static void Writer ()
                 std::cout << "Write failure" << std::endl;
                 exit(1);
             }
-            std::cout << "size is now " << rbuf.size() << std::endl;
+            std::cout << "size is now " << rbuf.size() <<
+                ", ring start is " << rbuf.ring_start() - buffer <<std::endl;
         }
     }
 }
@@ -172,7 +174,8 @@ static void Reader ()
                 std::cout << "Read failure " << std::endl;
                 exit(1);
             }
-            std::cout << "size is now " << rbuf.size() << std::endl;
+            std::cout << "size is now " << rbuf.size() <<
+                ", ring start is " << rbuf.ring_start() - buffer <<std::endl;
         }
         else if (!running)
         {


### PR DESCRIPTION
Ring buffer shifts back and forth to minimize short pushes and pops near right edge of ring buffer. This includes copying a limited number of elements in the buffer.